### PR TITLE
Set proper chart versions

### DIFF
--- a/woodpecker-agent/Chart.yaml
+++ b/woodpecker-agent/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: woodpecker-agent
 description: A Helm chart for the Woodpecker agent
 type: application
-version: next
+version: 1.0.0
 appVersion: "next"
 keywords:
 - continuous-delivery

--- a/woodpecker-agent/Chart.yaml
+++ b/woodpecker-agent/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: woodpecker-agent
 description: A Helm chart for the Woodpecker agent
 type: application
-version: <version>
-appVersion: "v<version>"
+version: next
+appVersion: "next"
 keywords:
 - continuous-delivery
 - continuous-deployment

--- a/woodpecker-server/Chart.yaml
+++ b/woodpecker-server/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: woodpecker-server
 description: A Helm chart for the Woodpecker server
 type: application
-version: <version>
-appVersion: "v<version>"
+version: 1.0.0
+appVersion: "1.0.0"
 keywords:
 - continuous-delivery
 - continuous-deployment

--- a/woodpecker-server/Chart.yaml
+++ b/woodpecker-server/Chart.yaml
@@ -3,7 +3,7 @@ name: woodpecker-server
 description: A Helm chart for the Woodpecker server
 type: application
 version: 1.0.0
-appVersion: "1.0.0"
+appVersion: "next"
 keywords:
 - continuous-delivery
 - continuous-deployment


### PR DESCRIPTION
Otherwise chart install via `helm-git` (and maybe others) don't work as they expect a valid semantic version.

fixes #11 