### PR TITLE
Update CI image versions

### DIFF
--- a/.woodpecker.yml
+++ b/.woodpecker.yml
@@ -1,5 +1,5 @@
 variables:
-  - &helm_image alpine/helm:3.5.3
+  - &helm_image alpine/helm:latest
 
 pipeline:
   set-version:
@@ -21,7 +21,7 @@ pipeline:
       - helm lint woodpecker-server/
 
   release:
-    image: quay.io/helmpack/chart-releaser:v1.4.0
+    image: quay.io/helmpack/chart-releaser:v1.5.0
     secrets:
       - source: github_token
         target: CR_TOKEN


### PR DESCRIPTION
fixes #8 

I don't see a downside in going rolling with `alpine/helm`. Saves some maintenance work in the future?

For the `chart-releaser` it might be better to stick to a fixed version?

