### PR TITLE
Enable dynamic provisioning of persistentVolumes

### DIFF
--- a/woodpecker-server/templates/statefulset.yaml
+++ b/woodpecker-server/templates/statefulset.yaml
@@ -96,7 +96,13 @@ spec:
       name: data
     spec:
       accessModes: [ "ReadWriteOnce" ]
+    {{- if .Values.persistentVolume.storageClass }}
+    {{- if (eq "-" .Values.persistentVolume.storageClass) }}
+      storageClassName: ""
+    {{- else }}
       storageClassName: {{ .Values.persistentVolume.storageClass }}
+    {{- end }}
+    {{- end }}
       resources:
         requests:
           storage: {{ .Values.persistentVolume.size }}


### PR DESCRIPTION
As I was trying to deploy woodpecker on kubernetes today, I noticed that my pod is sitting in a pending state due to the persistentVolume not being created. After a bit of reading, I learned that k8s only provisions volumes dynamically if `storageClassName` is completely omitted from the pvc definition. 

I basically copied this code from drone's helm chart, wihch uses dynamic provisioning by default, or you can disable it by setting `storageClass: "-"`. 

I couldn't test this since I'm not sure how to test helm changes locally, but the change is pretty simple so I assume it will work. 

Let me know if there's anything wrong with it and I'll be happy to fix!