### PR TITLE
Specify clusterIP or loadBalancerIP

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: woodpecker
 description: A Helm chart for Woodpecker CI
 type: application
-version: 0.1.5
+version: 0.2.0
 appVersion: "v0.15.9"
 home: https://woodpecker-ci.org/
 icon: https://avatars.githubusercontent.com/u/84780935?s=200&v=4
@@ -26,7 +26,7 @@ sources:
 
 dependencies:
   - name: server
-    version: "0.1.5"
+    version: "0.2.0"
     condition: server.enabled
   - name: agent
     version: "0.1.5"

--- a/charts/server/Chart.yaml
+++ b/charts/server/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: server
 description: A Helm chart for the Woodpecker server
 type: application
-version: 0.1.5
+version: 0.2.0
 appVersion: "v0.15.9"
 home: https://woodpecker-ci.org/
 icon: https://avatars.githubusercontent.com/u/84780935?s=200&v=4

--- a/charts/server/templates/service.yaml
+++ b/charts/server/templates/service.yaml
@@ -6,6 +6,12 @@ metadata:
     {{- include "woodpecker-server.labels" . | nindent 4 }}
 spec:
   type: {{ .Values.service.type }}
+  {{- with .Values.service.clusterIP }}
+  clusterIP: {{ . }}
+  {{- end }}
+  {{- with .Values.service.loadBalancerIP }}
+  loadBalancerIP: {{ . }}
+  {{- end }}
   ports:
     - protocol: TCP
       name: http

--- a/charts/server/values.yaml
+++ b/charts/server/values.yaml
@@ -83,6 +83,10 @@ service:
   type: ClusterIP
   # -- The port of the service
   port: &servicePort 80
+  # -- The cluster IP of the service (optional)
+  clusterIP:
+  # -- The loadbalancer IP of the service (optional)
+  loadBalancerIP:
 
 ingress:
   # -- Enable the ingress for the server component

--- a/values.yaml
+++ b/values.yaml
@@ -229,6 +229,10 @@ server:
     type: ClusterIP
     # -- The port of the service
     port: &servicePort 80
+    # -- The cluster IP of the service (optional)
+    clusterIP:
+    # -- The loadbalancer IP of the service (optional)
+    loadBalancerIP:
 
   ingress:
     # -- Enable the ingress for the server component


### PR DESCRIPTION
This PR allows to specify clusterIP or loadBalancerIP to the server service.

Note : the second commit bumps the chart version according to semver rules. Feel free to update or remove that commit if it breaks anything.