### PR TITLE
Don't check for version increment when linting PRs

### DIFF
--- a/ct.yaml
+++ b/ct.yaml
@@ -5,3 +5,4 @@ chart-dirs:
   - .
   - charts
 validate-maintainers: false
+check-version-increment: false


### PR DESCRIPTION
As this is handle by the release-helper now.

See https://ci.woodpecker-ci.org/repos/8958/pipeline/185/10 for https://github.com/woodpecker-ci/helm/pull/48