### PR TITLE
Remove duplicated steps

### DIFF
--- a/.woodpecker/release.yml
+++ b/.woodpecker/release.yml
@@ -6,19 +6,6 @@ when:
   - event: pull_request
 
 steps:
-  lint:
-    image: alpine/helm:latest
-    commands:
-      - helm lint --with-subcharts
-
-  test-chart:
-    image: quay.io/helmpack/chart-testing
-    commands:
-      - git fetch origin main --unshallow --no-tags
-      - git branch main origin/main || true
-      - ct list-changed --config ct.yaml
-      - ct lint --config ct.yaml
-
   pack-chart:
     image: quay.io/helmpack/chart-releaser:v1.5.0
     commands:


### PR DESCRIPTION
As we already depend on the test workflow we don't need those steps in the release workflow again