### PR TITLE
Fix release

### DIFF
--- a/.woodpecker/release.yml
+++ b/.woodpecker/release.yml
@@ -26,9 +26,7 @@ steps:
       - cr index --owner woodpecker-ci --git-repo woodpecker-ci.github.io --pages-branch master --package-path ../.cr-release-packages --index-path ../.cr-index/index.yaml --charts-repo https://woodpecker-ci.org --push --release-name-template "helm-{{ .Name }}-{{ .Version }}"
       - cd ..
       - rm -rf woodpecker-ci.github.io/
-      - pwd && ls -la
-      - git status
-      # - git reset --hard
+      - git reset --hard
     when:
       - event: tag
 

--- a/.woodpecker/release.yml
+++ b/.woodpecker/release.yml
@@ -6,19 +6,6 @@ when:
   - event: pull_request
 
 steps:
-  lint:
-    image: alpine/helm:latest
-    commands:
-      - helm lint --with-subcharts
-
-  test-chart:
-    image: quay.io/helmpack/chart-testing
-    commands:
-      - git fetch origin main --unshallow --no-tags
-      - git branch main origin/main || true
-      - ct list-changed --config ct.yaml
-      - ct lint --config ct.yaml
-
   pack-chart:
     image: quay.io/helmpack/chart-releaser:v1.5.0
     commands:

--- a/.woodpecker/release.yml
+++ b/.woodpecker/release.yml
@@ -22,9 +22,13 @@ steps:
       - git config --global user.name "woodpecker-bot"
       - cr upload --skip-existing --owner woodpecker-ci --git-repo woodpecker-ci.github.io --release-name-template "helm-{{ .Name }}-{{ .Version }}"
       - git clone https://github.com/woodpecker-ci/woodpecker-ci.github.io.git
-      - cd woodpecker-ci.github.io/ && cr index --owner woodpecker-ci --git-repo woodpecker-ci.github.io --pages-branch master --package-path ../.cr-release-packages --index-path ../.cr-index/index.yaml --charts-repo https://woodpecker-ci.org --push --release-name-template "helm-{{ .Name }}-{{ .Version }}"
-      - cd && rm -rf woodpecker-ci.github.io/
-      - git reset --hard
+      - cd woodpecker-ci.github.io/
+      - cr index --owner woodpecker-ci --git-repo woodpecker-ci.github.io --pages-branch master --package-path ../.cr-release-packages --index-path ../.cr-index/index.yaml --charts-repo https://woodpecker-ci.org --push --release-name-template "helm-{{ .Name }}-{{ .Version }}"
+      - cd ..
+      - rm -rf woodpecker-ci.github.io/
+      - pwd && ls -la
+      - git status
+      # - git reset --hard
     when:
       - event: tag
 

--- a/.woodpecker/release.yml
+++ b/.woodpecker/release.yml
@@ -23,7 +23,7 @@ steps:
       - cr upload --skip-existing --owner woodpecker-ci --git-repo woodpecker-ci.github.io --release-name-template "helm-{{ .Name }}-{{ .Version }}"
       - git clone https://github.com/woodpecker-ci/woodpecker-ci.github.io.git
       - cd woodpecker-ci.github.io/
-      - cr index --owner woodpecker-ci --git-repo woodpecker-ci.github.io --pages-branch master --package-path ../.cr-release-packages --index-path ../.cr-index/index.yaml --charts-repo https://woodpecker-ci.org --push --release-name-template "helm-{{ .Name }}-{{ .Version }}"
+      - cr index --owner woodpecker-ci --git-repo woodpecker-ci.github.io --pages-branch master --package-path ../.cr-release-packages --index-path ../.cr-index/index.yaml --push --release-name-template "helm-{{ .Name }}-{{ .Version }}"
       - cd ..
       - rm -rf woodpecker-ci.github.io/
       - git reset --hard


### PR DESCRIPTION
- Fixes https://ci.woodpecker-ci.org/repos/8958/pipeline/256/5

`cd` was sending the user to the home-directory `/root`, but not to the woodpecker workspace `/woodpecker/src` using `cd ..` solved the problem

- removed deprecated `--charts-repo` arg from `cr`