### PR TITLE
chore: enabled metrics with pod-monitor for statefulset

### DIFF
--- a/charts/server/templates/pod-monitor.yaml
+++ b/charts/server/templates/pod-monitor.yaml
@@ -1,0 +1,16 @@
+{{- if .Values.metrics.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: {{ include "woodpecker-server.fullname" . }}
+  labels:
+    {{- include "woodpecker-server.labels" . | nindent 4 }}
+spec:
+  selector:
+    matchLabels:
+    {{- include "woodpecker-server.selectorLabels" . | nindent 6 }}
+  podMetricsEndpoints:
+  - port: metrics
+    interval: {{ .Values.metrics.interval }}
+    path: {{ .Values.metrics.path }}
+{{- end }}

--- a/charts/server/templates/statefulset.yaml
+++ b/charts/server/templates/statefulset.yaml
@@ -57,6 +57,11 @@ spec:
             - name: grpc
               containerPort: 9000
               protocol: TCP
+          {{- if .Values.metrics.enabled }}
+            - name: metrics
+              containerPort: {{ .Values.metrics.port }}
+              protocol: TCP
+          {{- end }}
           livenessProbe:
             httpGet:
               path: /healthz
@@ -76,6 +81,10 @@ spec:
             {{- range $key, $value := .Values.env }}
             - name: {{ $key }}
               value: {{ $value | quote }}
+            {{- end }}
+            {{- if .Values.metrics.enabled }}
+            - name: WOODPECKER_METRICS_SERVER_ADDR
+              value: ":{{ .Values.metrics.port }}"
             {{- end }}
           envFrom:
             {{- range .Values.extraSecretNamesForEnvFrom }}

--- a/charts/server/values.yaml
+++ b/charts/server/values.yaml
@@ -145,3 +145,10 @@ affinity: {}
 
 # -- Overrides the default DNS configuration
 dnsConfig: {}
+
+# -- Enabled internal metrics endpoint.
+metrics:
+  enabled: false
+  port: 9001
+  interval: 60s
+  path: /metrics


### PR DESCRIPTION
# Why

Enable metrics endpoint with a different port.

# How 

Add a new environment variable and expose the port. 