### PR TITLE
add documentation for extra volume mounts in agent

### DIFF
--- a/charts/agent/values.yaml
+++ b/charts/agent/values.yaml
@@ -39,17 +39,23 @@ dind:
     DOCKER_DRIVER: "overlay2"
   # -- Defines the resources for Docker-in-Docker
   resources: {}
+  # -- Defines extra volumes to mount in the Docker-in-Docker container
+  extraVolumeMounts: []
+    # - name: docker-config
+    #   mountPath: /etc/docker/daemon.json
+    #   subPath: daemon.json
 
 # -- Add extra secret that is contains environment variables
 extraSecretNamesForEnvFrom:
   - woodpecker-secret
 
+# -- Additional volumes that can be mounted in containers
 extraVolumes: []
-  # - name: data-volume
-  #   persistentVolumeClaim:
-  #     claimName: example
+  # - name: docker-config
+  #   mountPath: /etc/docker/daemon.json
+  #   subPath: daemon.json
 
-## Additional volumes that will be attached to the agent container
+# -- Additional volumes that will be attached to the agent container
 extraVolumeMounts: []
   # - name: ca-certs
   #   mountPath: /etc/ssl/certs/ca-certificates.crt

--- a/charts/agent/values.yaml
+++ b/charts/agent/values.yaml
@@ -52,8 +52,11 @@ extraSecretNamesForEnvFrom:
 # -- Additional volumes that can be mounted in containers
 extraVolumes: []
   # - name: docker-config
-  #   mountPath: /etc/docker/daemon.json
-  #   subPath: daemon.json
+  #   configMap:
+  #     name: docker-config
+  # - name: data-volume
+  #   persistentVolumeClaim:
+  #     claimName: example
 
 # -- Additional volumes that will be attached to the agent container
 extraVolumeMounts: []

--- a/values.yaml
+++ b/values.yaml
@@ -46,10 +46,26 @@ agent:
       DOCKER_DRIVER: "overlay2"
     # -- Defines the resources for Docker-in-Docker
     resources: {}
+      # -- Defines extra volumes to mount in the Docker-in-Docker container
+    extraVolumeMounts: []
+    # - name: docker-config
+    #   mountPath: /etc/docker/daemon.json
+    #   subPath: daemon.json
 
   # -- Add extra secret that is contains environment variables
   extraSecretNamesForEnvFrom:
     - woodpecker-secret
+
+  # -- Additional volumes that can be mounted in containers
+  extraVolumes: []
+    # - name: docker-config
+    #   mountPath: /etc/docker/daemon.json
+    #   subPath: daemon.json
+
+  # -- Additional volumes that will be attached to the agent container
+  extraVolumeMounts: []
+    # - name: ca-certs
+    #   mountPath: /etc/ssl/certs/ca-certificates.crt
 
   # -- The image pull secrets
   imagePullSecrets: []

--- a/values.yaml
+++ b/values.yaml
@@ -59,8 +59,11 @@ agent:
   # -- Additional volumes that can be mounted in containers
   extraVolumes: []
     # - name: docker-config
-    #   mountPath: /etc/docker/daemon.json
-    #   subPath: daemon.json
+    #   configMap:
+    #     name: docker-config
+    # - name: data-volume
+    #   persistentVolumeClaim:
+    #     claimName: example
 
   # -- Additional volumes that will be attached to the agent container
   extraVolumeMounts: []


### PR DESCRIPTION
I noticed this documentation was either missing or had incorrect syntax.