### PR TITLE
Publish chart to OCI registry (alongside gh-pages)

### DIFF
--- a/.woodpecker/release.yml
+++ b/.woodpecker/release.yml
@@ -30,6 +30,17 @@ steps:
     when:
       - event: tag
 
+  release-oci:
+    image: alpine/helm:3.13.0
+    secrets: [gh_token_packages]
+    commands:
+      - helm package charts/otf-agent --version ${CI_COMMIT_TAG}
+      - echo ${GH_TOKEN_PACKAGES} | helm registry login -u woodpeckerci ghcr.io --password-stdin
+      - helm push otf-agent-${CI_COMMIT_TAG}.tgz oci://ghcr.io/woodpeckerci/helm
+      - helm registry logout ghcr.io
+    when:
+      - event: tag
+
   update-readme:
     image: jnorwood/helm-docs:v1.11.0
     commands:
@@ -38,7 +49,7 @@ steps:
       - cat README.md
 
   push-readme:
-    image: appleboy/drone-git-push
+    image: appleboy/drone-git-push:1.0.5
     settings:
       remote: ssh://git@github.com/woodpecker-ci/helm.git
       branch: main

--- a/.woodpecker/release.yml
+++ b/.woodpecker/release.yml
@@ -32,12 +32,12 @@ steps:
 
   release-oci:
     image: alpine/helm:3.13.0
-    secrets: [gh_token_packages]
+    secrets: [dockerhub_token]
     commands:
       - helm package . --version ${CI_COMMIT_TAG}
-      - echo ${GH_TOKEN_PACKAGES} | helm registry login -u woodpeckerci ghcr.io --password-stdin
-      - helm push woodpecker-${CI_COMMIT_TAG}.tgz oci://ghcr.io/woodpeckerci/helm
-      - helm registry logout ghcr.io
+      - echo ${DOCKERHUB_TOKEN} | helm registry login -u woodpeckerci registry-1.docker.io --password-stdin
+      - helm push woodpecker-${CI_COMMIT_TAG}.tgz oci://registry-1.docker.io/woodpeckerci/helm
+      - helm registry logout registry-1.docker.io
     when:
       - event: tag
 

--- a/.woodpecker/release.yml
+++ b/.woodpecker/release.yml
@@ -34,9 +34,9 @@ steps:
     image: alpine/helm:3.13.0
     secrets: [gh_token_packages]
     commands:
-      - helm package charts/otf-agent --version ${CI_COMMIT_TAG}
+      - helm package . --version ${CI_COMMIT_TAG}
       - echo ${GH_TOKEN_PACKAGES} | helm registry login -u woodpeckerci ghcr.io --password-stdin
-      - helm push otf-agent-${CI_COMMIT_TAG}.tgz oci://ghcr.io/woodpeckerci/helm
+      - helm push woodpecker-${CI_COMMIT_TAG}.tgz oci://ghcr.io/woodpeckerci/helm
       - helm registry logout ghcr.io
     when:
       - event: tag

--- a/.woodpecker/release.yml
+++ b/.woodpecker/release.yml
@@ -49,7 +49,7 @@ steps:
       - cat README.md
 
   push-readme:
-    image: appleboy/drone-git-push:1.0.5
+    image: appleboy/drone-git-push
     settings:
       remote: ssh://git@github.com/woodpecker-ci/helm.git
       branch: main

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ helm repo add woodpecker https://woodpecker-ci.org/
 helm install woodpecker woodpecker/woodpecker
 
 # alternatively via OCI
-helm repo add woodpecker oci://ghcr.io/woodpeckerci/woodpecker
+helm repo add woodpecker oci://registry-1.docker.io/woodpeckerci/woodpecker
 helm install woodpecker woodpecker/woodpecker
 ```
 

--- a/README.md
+++ b/README.md
@@ -12,8 +12,11 @@ To install the latest release of the chart:
 
 ```sh
 helm repo add woodpecker https://woodpecker-ci.org/
+helm install woodpecker woodpecker/woodpecker
 
-helm install woodpecker-agent woodpecker/woodpecker
+# alternatively via OCI
+helm repo add woodpecker oci://ghcr.io/woodpeckerci/woodpecker
+helm install woodpecker woodpecker/woodpecker
 ```
 
 **Note**: The `woodpecker/woodpecker` chart contains both the server and the agent.


### PR DESCRIPTION
Publish chart to GH package registry alongside the gh-pages hosting. Supported since helm 3.8.

Advantages: 
- "Proper" chart release page
- Download count tracking
- Historic version overview

Example: https://github.com/pat-s/otf-agent-helm/pkgs/container/otf-agent-helm%2Fotf-agent

Needs:

- [ ] A GH PAT with `packages` scope
- [ ] After the first publish, a manual linking of the package to the repo