### PR TITLE
Set the prefixed tag if not provided via Values

### DIFF
--- a/Chart.lock
+++ b/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: server
   repository: ""
-  version: 1.0.0
+  version: 1.0.1
 - name: agent
   repository: ""
-  version: 0.2.0
-digest: sha256:289a2b8d226478642d244f6581215feb7bb142c608d5ceedb3a2aa8b58166688
-generated: "2023-10-16T17:29:54.577011353+02:00"
+  version: 0.2.1
+digest: sha256:22caa84cdf71be2fdfa856eaea7d97f1f45fb892bf9f6c97ed133c12145c4e24
+generated: "2023-11-14T09:24:31.932204+01:00"

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: woodpecker
 description: A Helm chart for Woodpecker CI
 type: application
-version: 0.4.2
+version: 0.4.3
 appVersion: 1.0.2
 home: https://woodpecker-ci.org/
 icon: https://avatars.githubusercontent.com/u/84780935?s=200&v=4
@@ -26,8 +26,8 @@ sources:
 
 dependencies:
   - name: server
-    version: 1.0.0
+    version: 1.0.1
     condition: server.enabled
   - name: agent
-    version: 0.2.0
+    version: 0.2.1
     condition: agent.enabled

--- a/charts/agent/Chart.yaml
+++ b/charts/agent/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: agent
 description: A Helm chart for the Woodpecker agent
 type: application
-version: 0.2.0
+version: 0.2.1
 appVersion: 1.0.2
 home: https://woodpecker-ci.org/
 icon: https://avatars.githubusercontent.com/u/84780935?s=200&v=4

--- a/charts/agent/templates/_helpers.tpl
+++ b/charts/agent/templates/_helpers.tpl
@@ -60,3 +60,9 @@ Create the name of the service account to use
 {{- default "default" .Values.serviceAccount.name }}
 {{- end }}
 {{- end }}
+
+Set the default image tag with the 'v' prefix
+*/}}
+{{- define "woodpecker-agent.defaultImageTag" -}}
+{{- printf "v%s" (default .Chart.AppVersion) }}
+{{- end -}}

--- a/charts/agent/templates/deployment.yaml
+++ b/charts/agent/templates/deployment.yaml
@@ -35,7 +35,7 @@ spec:
         - name: {{ .Chart.Name }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
-          image: "{{ .Values.image.registry }}/{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          image: "{{ .Values.image.registry }}/{{ .Values.image.repository }}:{{ .Values.image.tag | default ( include "woodpecker-agent.defaultImageTag" . ) }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           {{- with .Values.command }}
           command:

--- a/charts/server/Chart.yaml
+++ b/charts/server/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: server
 description: A Helm chart for the Woodpecker server
 type: application
-version: 1.0.0
+version: 1.0.1
 appVersion: 1.0.2
 home: https://woodpecker-ci.org/
 icon: https://avatars.githubusercontent.com/u/84780935?s=200&v=4

--- a/charts/server/templates/_helpers.tpl
+++ b/charts/server/templates/_helpers.tpl
@@ -60,3 +60,10 @@ Create the name of the service account to use
 {{- default "default" .Values.serviceAccount.name }}
 {{- end }}
 {{- end }}
+
+{{/*
+Set the default image tag with the 'v' prefix
+*/}}
+{{- define "woodpecker-server.defaultImageTag" -}}
+{{- printf "v%s" (default .Chart.AppVersion) }}
+{{- end -}}

--- a/charts/server/templates/statefulset.yaml
+++ b/charts/server/templates/statefulset.yaml
@@ -40,7 +40,7 @@ spec:
         - name: {{ .Chart.Name }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
-          image: "{{ .Values.image.registry }}/{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          image: "{{ .Values.image.registry }}/{{ .Values.image.repository }}:{{ .Values.image.tag | default ( include "woodpecker-server.defaultImageTag" . ) }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           {{- with .Values.command }}
           command:


### PR DESCRIPTION
When the image tag is not defined in Values, it's using the appVersion from the chart definition, though there is no such tag in the default container registry, because images there have the 'v' prefix.

In this commit, I'm setting the default image tag to be prefixed with 'v' in case it's not provided via Values