### PR TITLE
add Postgresql subchart for integrated db deployment

### DIFF
--- a/charts/woodpecker/Chart.yaml
+++ b/charts/woodpecker/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: woodpecker
 description: A Helm chart for Woodpecker CI
 type: application
-version: 1.0.3
+version: 1.1.3
 # renovate: datasource=github-releases depName=woodpecker-ci/woodpecker extractVersion=^v(?<version>.*)$
 appVersion: 2.1.1
 home: https://woodpecker-ci.org/
@@ -27,7 +27,7 @@ sources:
 
 dependencies:
   - name: server
-    version: 1.0.0
+    version: 1.1.0
     condition: server.enabled
   - name: agent
     version: 0.2.0

--- a/charts/woodpecker/charts/server/Chart.lock
+++ b/charts/woodpecker/charts/server/Chart.lock
@@ -1,0 +1,6 @@
+dependencies:
+- name: postgresql
+  repository: https://charts.bitnami.com/bitnami
+  version: 13.2.26
+digest: sha256:715fd0f06169289f21bffa49765adf61f56d9aa70ad295d4332b508b98248bdb
+generated: "2023-12-29T12:09:22.277024958+01:00"

--- a/charts/woodpecker/charts/server/Chart.yaml
+++ b/charts/woodpecker/charts/server/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: server
 description: A Helm chart for the Woodpecker server
 type: application
-version: 1.0.0
+version: 1.1.0
 # renovate: datasource=github-releases depName=woodpecker-ci/woodpecker extractVersion=^v(?<version>.*)$
 appVersion: 2.1.1
 home: https://woodpecker-ci.org/

--- a/charts/woodpecker/charts/server/Chart.yaml
+++ b/charts/woodpecker/charts/server/Chart.yaml
@@ -23,3 +23,9 @@ maintainers:
   - name: Woodpecker Maintainers
     email: owner@woodpecker-ci.org
     url: https://github.com/woodpecker-ci
+
+dependencies:
+  - name: postgresql
+    version: ~13.2.24
+    repository: https://charts.bitnami.com/bitnami
+    condition: postgresql.enabled

--- a/charts/woodpecker/charts/server/templates/statefulset.yaml
+++ b/charts/woodpecker/charts/server/templates/statefulset.yaml
@@ -89,6 +89,12 @@ spec:
             - name: WOODPECKER_METRICS_SERVER_ADDR
               value: ":{{ .Values.metrics.port }}"
             {{- end }}
+            {{- if .Values.postgresql.enabled }}
+            - name: WOODPECKER_DATABASE_DRIVER
+              value: "postgres"
+            - name: WOODPECKER_DATABASE_DATASOURCE
+              value: "postgres://{{ .Values.postgresql.auth.username }}:{{ .Values.postgresql.auth.password }}@{{ .Release.Name }}-postgresql:5432/{{ .Values.postgresql.auth.database }}?sslmode=disable"
+            {{- end }}
           envFrom:
             {{- range .Values.extraSecretNamesForEnvFrom }}
             - secretRef:

--- a/charts/woodpecker/charts/server/values.yaml
+++ b/charts/woodpecker/charts/server/values.yaml
@@ -193,3 +193,18 @@ metrics:
   # -- enable metrics in woodpecker
   enabled: false
   port: 9001
+
+# Enable and configure postgresql database subchart under this key.
+# If enabled, the app's db envs will be set for you.
+# [[ref]](https://github.com/bitnami/charts/tree/main/bitnami/postgresql)
+# @default -- See [values.yaml](./values.yaml)
+postgresql:
+  # -- provision an instance of the postgresql sub-chart
+  enabled: true
+  auth:
+    # -- define database schema name that should be available
+    database: woodpecker
+    # -- username to connect to the database
+    username: woodpecker
+    # -- password to connect to the database
+    password: changeme

--- a/charts/woodpecker/values.yaml
+++ b/charts/woodpecker/values.yaml
@@ -303,3 +303,18 @@ server:
 
   # -- Overrides the default DNS configuration
   dnsConfig: {}
+
+  # Enable and configure postgresql database subchart under this key.
+  # If enabled, the app's db envs will be set for you.
+  # [[ref]](https://github.com/bitnami/charts/tree/main/bitnami/postgresql)
+  # @default -- See [values.yaml](./values.yaml)
+  postgresql:
+    # -- provision an instance of the postgresql sub-chart
+    enabled: true
+    auth:
+      # -- define database schema name that should be available
+      database: woodpecker
+      # -- username to connect to the database
+      username: woodpecker
+      # -- password to connect to the database
+      password: changeme


### PR DESCRIPTION
to easily spin up a woodpecker deployment in k8s i added the bitnami postgresql chart as a subchart to the server chart.
that way enabling it via values (defaults to true) it deploys a pgsql alongside woodpecker-server and configures the environment of the server accordingly