### PR TITLE
Allow/improve automatic secret creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This repository contains the helm charts of the [Woodpecker](https://woodpecker-
 
 Please see the README's of the sub-charts for their configuration options:
 
-- [woodpecker](./charts/woodpecker/charts/woodpecker/README.md)
+- [woodpecker](./charts/woodpecker/README.md)
 - [(server)](./charts/woodpecker/charts/server/README.md)
 - [(agent)](./charts/woodpecker/charts/agent/README.md)
 

--- a/charts/woodpecker/README.md
+++ b/charts/woodpecker/README.md
@@ -128,6 +128,7 @@ resource "helm_release" "woodpecker" {
 | server.podAnnotations | object | `{}` | Add pod annotations |
 | server.podSecurityContext | object | `{}` | Add pod security context |
 | server.resources | object | `{}` | Specifies the ressources for the server component |
+| server.secrets | list | `[{"name":"woodpecker-secret"}]` | Create a generic secret to store things in, e.g. env values |
 | server.securityContext | object | `{}` | Add security context |
 | server.service.clusterIP | string | `nil` | The cluster IP of the service (optional) |
 | server.service.loadBalancerIP | string | `nil` | The loadbalancer IP of the service (optional) |

--- a/charts/woodpecker/charts/agent/README.md
+++ b/charts/woodpecker/charts/agent/README.md
@@ -44,6 +44,7 @@ A Helm chart for the Woodpecker agent
 | podSecurityContext | object | `{}` | Add pod security context |
 | replicaCount | int | `2` | The number of replicas for the deployment |
 | resources | object | `{}` | Specifies the resources for the agent component |
+| secrets | object | `{}` | Create an agent secret |
 | securityContext | object | `{}` | Add security context |
 | serviceAccount.annotations | object | `{}` | Annotations to add to the service account |
 | serviceAccount.create | bool | `true` | Specifies whether a service account should be created (also see RBAC subsection) |

--- a/charts/woodpecker/charts/agent/templates/secret.yml
+++ b/charts/woodpecker/charts/agent/templates/secret.yml
@@ -1,7 +1,12 @@
-{{- if .Values.createSecret }}
+{{- range .Values.secrets }}
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ .Values.secretName }}
+  name: {{ .name }}
+  namespace: {{ $.namespace }}
 type: Opaque
+data:
+  {{- range $key, $value := .data }}
+  {{ $key }}: {{ $value | b64enc }}
+  {{- end }}
 {{- end }}

--- a/charts/woodpecker/charts/agent/values.yaml
+++ b/charts/woodpecker/charts/agent/values.yaml
@@ -33,6 +33,12 @@ env:
 extraSecretNamesForEnvFrom:
   - woodpecker-secret
 
+# -- Create an agent secret
+secrets: {}
+#  - name: woodpecker-secret
+#    data:
+#      WOODPECKER_AGENT_SECRET: ${WOODPECKER_AGENT_SECRET}
+
 # -- Additional volumes that can be mounted in containers
 extraVolumes: []
   # - name: docker-config

--- a/charts/woodpecker/charts/server/README.md
+++ b/charts/woodpecker/charts/server/README.md
@@ -68,6 +68,7 @@ A Helm chart for the Woodpecker server
 | prometheus.rules.enabled | bool | `false` | deploy prometheus-rules |
 | prometheus.rules.labels | object | `{}` | add labels to prometheus-rules (to be selected by prometheus-operator) |
 | resources | object | `{}` | Specifies the ressources for the server component |
+| secrets | list | `[{"name":"woodpecker-secret"}]` | Create a generic secret to store things in, e.g. env values |
 | securityContext | object | `{}` | Add security context |
 | service.clusterIP | string | `nil` | The cluster IP of the service (optional) |
 | service.loadBalancerIP | string | `nil` | The loadbalancer IP of the service (optional) |

--- a/charts/woodpecker/charts/server/templates/secret-check-job.yaml
+++ b/charts/woodpecker/charts/server/templates/secret-check-job.yaml
@@ -1,0 +1,15 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: pre-install-agent-secret-check
+  annotations:
+    "helm.sh/hook": pre-install
+spec:
+  template:
+    spec:
+      containers:
+      - name: check-agent-secret
+        image: finalgene/openssh:9
+        command: ["openssl"]
+        args: ["rand", "-hex", "32"]
+      restartPolicy: OnFailure

--- a/charts/woodpecker/charts/server/templates/secret.yaml
+++ b/charts/woodpecker/charts/server/templates/secret.yaml
@@ -11,20 +11,3 @@ data:
   {{ $key }}: {{ $value | b64enc }}
   {{- end }}
 {{- end }}
-
----
-apiVersion: batch/v1
-kind: Job
-metadata:
-  name: pre-install-agent-secret-check
-  annotations:
-    "helm.sh/hook": pre-install
-spec:
-  template:
-    spec:
-      containers:
-      - name: check-agent-secret
-        image: finalgene/openssh:9
-        command: ["openssl"]
-        args: ["rand", "-hex", "32"]
-      restartPolicy: OnFailure

--- a/charts/woodpecker/charts/server/templates/secret.yaml
+++ b/charts/woodpecker/charts/server/templates/secret.yaml
@@ -1,10 +1,15 @@
-{{- if .Values.createSecret }}
+{{- range .Values.secrets }}
+---
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ .Values.secretName }}
-  namespace: {{ .namespace }}
+  name: {{ .name }}
+  namespace: {{ $.namespace }}
 type: Opaque
+data:
+  {{- range $key, $value := .data }}
+  {{ $key }}: {{ $value | b64enc }}
+  {{- end }}
 {{- end }}
 
 ---

--- a/charts/woodpecker/charts/server/unittests/statefulset/__snapshot__/secrets.yaml.snap
+++ b/charts/woodpecker/charts/server/unittests/statefulset/__snapshot__/secrets.yaml.snap
@@ -1,0 +1,8 @@
+can create an extra secret with proper values:
+  1: |
+    BAZ: Zm9v
+    FOO: YmFy
+populates the custom secret values properly:
+  1: |
+    BAZ: Zm9v
+    FOO: YmFy

--- a/charts/woodpecker/charts/server/unittests/statefulset/secrets.yaml
+++ b/charts/woodpecker/charts/server/unittests/statefulset/secrets.yaml
@@ -1,0 +1,106 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/helm-unittest/helm-unittest/main/schema/helm-testsuite.json
+suite: secrets
+release:
+  name: woodpecker-unittests
+  namespace: testing
+templates:
+  - templates/secret.yaml
+tests:
+  - it: creates a default `woodpecker-secret` secret with default values
+    values:
+      - ../../values.yaml
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Secret
+      - matchRegex:
+          path: metadata.name
+          pattern: woodpecker-secret
+  - it: populates the custom secret values properly
+    set:
+      secrets:
+        - name: woodpecker-secret
+          data:
+            FOO: bar
+            BAZ: foo
+    asserts:
+      - matchSnapshot:
+          path: data
+  - it: can create an extra secret with proper values
+    set:
+      secrets:
+        - name: woodpecker-secret
+          data:
+            FOO: bar
+            BAZ: foo
+        - name: extra-secret
+          data:
+            FOO: bar
+            BAZ: foo
+    documentSelector:
+      path: metadata.name
+      value: extra-secret
+    asserts:
+      - hasDocuments:
+          count: 2
+      - isKind:
+          of: Secret
+      - matchRegex:
+          path: metadata.name
+          pattern: extra-secret
+      - matchSnapshot:
+          path: data
+---
+suite: secret-check-job
+release:
+  name: woodpecker-unittests
+  namespace: testing
+templates:
+  - templates/secret.yaml
+tests:
+  - it: creates a default `woodpecker-secret` secret with default values
+    values:
+      - ../../values.yaml
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Secret
+      - matchRegex:
+          path: metadata.name
+          pattern: woodpecker-secret
+  - it: populates the custom secret values properly
+    set:
+      secrets:
+        - name: woodpecker-secret
+          data:
+            FOO: bar
+            BAZ: foo
+    asserts:
+      - matchSnapshot:
+          path: data
+  - it: can create an extra secret with proper values
+    set:
+      secrets:
+        - name: woodpecker-secret
+          data:
+            FOO: bar
+            BAZ: foo
+        - name: extra-secret
+          data:
+            FOO: bar
+            BAZ: foo
+    documentSelector:
+      path: metadata.name
+      value: extra-secret
+    asserts:
+      - hasDocuments:
+          count: 2
+      - isKind:
+          of: Secret
+      - matchRegex:
+          path: metadata.name
+          pattern: extra-secret
+      - matchSnapshot:
+          path: data

--- a/charts/woodpecker/charts/server/values.yaml
+++ b/charts/woodpecker/charts/server/values.yaml
@@ -41,6 +41,11 @@ extraSecretNamesForEnvFrom:
   # - woodpecker-github-secret
   - woodpecker-secret
 
+# -- Create a generic secret to store things in, e.g. env values
+secrets:
+  - name: woodpecker-secret
+    #  data:
+    #    WOODPECKER_AGENT_SECRET: ${WOODPECKER_AGENT_SECRET}
 
 prometheus:
   podmonitor:

--- a/charts/woodpecker/values.yaml
+++ b/charts/woodpecker/values.yaml
@@ -183,6 +183,10 @@ server:
     # - woodpecker-github-secret
     - woodpecker-secret
 
+  # -- Create a generic secret to store things in, e.g. env values
+  secrets:
+    - name: woodpecker-secret
+
   # -- Additional volumes that can be mounted in containers
   extraVolumes:
     []


### PR DESCRIPTION
I had to do some reverse-engineering to figure out how to run the chart, so I'm making some small changes in an effort to help new people start:

- Explained what env vars need to be set and set up links to docs.
- Modified the unused secret template to allow for secret creation and input of encrypted values.

Happy to change the approach if this one is not correct. Please let me know.