### PR TITLE
fix volumeMounts if persistentVolume is not enabled

### DIFF
--- a/charts/woodpecker/charts/server/templates/statefulset.yaml
+++ b/charts/woodpecker/charts/server/templates/statefulset.yaml
@@ -77,7 +77,7 @@ spec:
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           volumeMounts:
-            {{- if .Values.persistentVolume }}
+            {{- if .Values.persistentVolume.enabled }}
             - name: data
               mountPath: {{ .Values.persistentVolume.mountPath }}
             {{- end }}


### PR DESCRIPTION
When using database for persistence no volumes are required. 