### PR TITLE
Remove PV from server

### DIFF
--- a/charts/woodpecker/README.md
+++ b/charts/woodpecker/README.md
@@ -122,10 +122,6 @@ resource "helm_release" "woodpecker" {
 | server.initContainers | list | `[]` | Add additional init containers to the pod (evaluated as a template) |
 | server.nameOverride | string | `""` | Overrides the name of the helm chart of the server component |
 | server.nodeSelector | object | `{}` | Defines the labels of the node where the server component must be running |
-| server.persistentVolume.enabled | bool | `true` | Enable the creation of the persistent volume |
-| server.persistentVolume.mountPath | string | `"/var/lib/woodpecker"` | Defines the path where the volume should be mounted |
-| server.persistentVolume.size | string | `"10Gi"` | Defines the size of the persistent volume |
-| server.persistentVolume.storageClass | string | `""` | Defines the storageClass of the persistent volume |
 | server.podAnnotations | object | `{}` | Add pod annotations |
 | server.podSecurityContext | object | `{}` | Add pod security context |
 | server.resources | object | `{}` | Specifies the ressources for the server component |

--- a/charts/woodpecker/charts/server/Chart.yaml
+++ b/charts/woodpecker/charts/server/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: server
 description: A Helm chart for the Woodpecker server
 type: application
-version: 1.0.0
+version: 1.1.0
 # renovate: datasource=github-releases depName=woodpecker-ci/woodpecker extractVersion=^v(?<version>.*)$
 appVersion: 2.3.0
 home: https://woodpecker-ci.org/

--- a/charts/woodpecker/charts/server/README.md
+++ b/charts/woodpecker/charts/server/README.md
@@ -1,6 +1,6 @@
 # server
 
-![Version: 1.0.0](https://img.shields.io/badge/Version-1.0.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.3.0](https://img.shields.io/badge/AppVersion-2.3.0-informational?style=flat-square)
+![Version: 1.1.0](https://img.shields.io/badge/Version-1.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.3.0](https://img.shields.io/badge/AppVersion-2.3.0-informational?style=flat-square)
 
 A Helm chart for the Woodpecker server
 

--- a/charts/woodpecker/charts/server/README.md
+++ b/charts/woodpecker/charts/server/README.md
@@ -55,10 +55,6 @@ A Helm chart for the Woodpecker server
 | metrics.enabled | bool | `false` | enable metrics in woodpecker |
 | nameOverride | string | `""` | Overrides the name of the helm chart of the server component |
 | nodeSelector | object | `{}` | Defines the labels of the node where the server component must be running |
-| persistentVolume.enabled | bool | `true` | Enable the creation of the persistent volume |
-| persistentVolume.mountPath | string | `"/var/lib/woodpecker"` | Defines the path where the volume should be mounted |
-| persistentVolume.size | string | `"10Gi"` | Defines the size of the persistent volume |
-| persistentVolume.storageClass | string | `""` | Defines the storageClass of the persistent volume |
 | podAnnotations | object | `{}` | Add pod annotations |
 | podSecurityContext | object | `{}` | Add pod security context |
 | prometheus.podmonitor.enabled | bool | `false` | deploy podmonitor |

--- a/charts/woodpecker/charts/server/templates/statefulset.yaml
+++ b/charts/woodpecker/charts/server/templates/statefulset.yaml
@@ -77,10 +77,6 @@ spec:
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           volumeMounts:
-            {{- if .Values.persistentVolume.enabled }}
-            - name: data
-              mountPath: {{ .Values.persistentVolume.mountPath }}
-            {{- end }}
             {{- with .Values.extraVolumeMounts }}
             {{- toYaml . | nindent 12 }}
             {{- end }}
@@ -118,20 +114,3 @@ spec:
       dnsConfig:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-  {{- if .Values.persistentVolume.enabled }}
-  volumeClaimTemplates:
-  - metadata:
-      name: data
-    spec:
-      accessModes: [ "ReadWriteOnce" ]
-    {{- if .Values.persistentVolume.storageClass }}
-    {{- if (eq "-" .Values.persistentVolume.storageClass) }}
-      storageClassName: ""
-    {{- else }}
-      storageClassName: {{ .Values.persistentVolume.storageClass }}
-    {{- end }}
-    {{- end }}
-      resources:
-        requests:
-          storage: {{ .Values.persistentVolume.size }}
-  {{- end }}

--- a/charts/woodpecker/charts/server/values.yaml
+++ b/charts/woodpecker/charts/server/values.yaml
@@ -94,16 +94,6 @@ extraVolumeMounts:
 # -- Add additional init containers to the pod (evaluated as a template)
 initContainers: []
 
-persistentVolume:
-  # -- Enable the creation of the persistent volume
-  enabled: true
-  # -- Defines the size of the persistent volume
-  size: 10Gi
-  # -- Defines the path where the volume should be mounted
-  mountPath: '/var/lib/woodpecker'
-  # -- Defines the storageClass of the persistent volume
-  storageClass: ''
-
 # -- The image pull secrets
 imagePullSecrets: []
 # -- Overrides the name of the helm chart of the server component

--- a/charts/woodpecker/values.yaml
+++ b/charts/woodpecker/values.yaml
@@ -206,16 +206,6 @@ server:
   # -- Add additional init containers to the pod (evaluated as a template)
   initContainers: []
 
-  persistentVolume:
-    # -- Enable the creation of the persistent volume
-    enabled: true
-    # -- Defines the size of the persistent volume
-    size: 10Gi
-    # -- Defines the path where the volume should be mounted
-    mountPath: '/var/lib/woodpecker'
-    # -- Defines the storageClass of the persistent volume
-    storageClass: ''
-
   # -- The image pull secrets
   imagePullSecrets: []
   # -- Overrides the name of the helm chart of the server component


### PR DESCRIPTION
see #160 

The server doesn't need a PV as all data is stored in the DB and all config is done via env vars/secrets. 

I just checked our own install and the PV is empty.

Not sure if this is an enhancement of bugfix but it shouldn't be breaking as I can't see how anyone has anything stored in that PV. Hence deleting shouldn't harm existing installations.