### PR TITLE
Fix unittest after plugin update

### DIFF
--- a/charts/woodpecker/charts/server/unittests/statefulset/secrets.yaml
+++ b/charts/woodpecker/charts/server/unittests/statefulset/secrets.yaml
@@ -34,21 +34,14 @@ tests:
           data:
             FOO: bar
             BAZ: foo
-        - name: extra-secret
-          data:
-            FOO: bar
-            BAZ: foo
-    documentSelector:
-      path: metadata.name
-      value: extra-secret
     asserts:
       - hasDocuments:
-          count: 2
+          count: 1
       - isKind:
           of: Secret
       - matchRegex:
           path: metadata.name
-          pattern: extra-secret
+          pattern: woodpecker-secret
       - matchSnapshot:
           path: data
 ---


### PR DESCRIPTION
The test is still defined in another one in the same file (it was duplicated beforehand and the selector was actually buggy in the plugin).