### PR TITLE
Improve agent sts pvc tests

### DIFF
--- a/charts/woodpecker/charts/agent/templates/statefulset.yaml
+++ b/charts/woodpecker/charts/agent/templates/statefulset.yaml
@@ -65,10 +65,6 @@ spec:
             {{- if .Values.extraVolumeMounts }}
             {{- toYaml .Values.extraVolumeMounts | nindent 12 }}
             {{- end }}
-          {{- else }}
-          volumeMounts:
-            - name: data
-              mountPath: /data
           {{- end }}
           env:
             {{- range $key, $value := .Values.env }}
@@ -104,10 +100,6 @@ spec:
         {{- if .Values.extraVolumes }}
           {{- toYaml .Values.extraVolumes | nindent 6 }}
         {{- end }}
-      {{- else }}
-      volumes:
-        - name: data
-          emptyDir: {}
       {{- end }}
       {{- with .Values.dnsConfig }}
       dnsConfig:

--- a/charts/woodpecker/charts/agent/templates/statefulset.yaml
+++ b/charts/woodpecker/charts/agent/templates/statefulset.yaml
@@ -130,7 +130,4 @@ spec:
         resources:
           requests:
             storage: {{ .Values.persistence.size }}
-{{- else if (not .Values.persistence.enabled) }}
-        - name: data
-          emptyDir: {}
 {{- end }}

--- a/charts/woodpecker/charts/agent/templates/statefulset.yaml
+++ b/charts/woodpecker/charts/agent/templates/statefulset.yaml
@@ -65,6 +65,10 @@ spec:
             {{- if .Values.extraVolumeMounts }}
             {{- toYaml .Values.extraVolumeMounts | nindent 12 }}
             {{- end }}
+          {{- else }}
+          volumeMounts:
+            - name: data
+              mountPath: /data
           {{- end }}
           env:
             {{- range $key, $value := .Values.env }}

--- a/charts/woodpecker/charts/agent/templates/statefulset.yaml
+++ b/charts/woodpecker/charts/agent/templates/statefulset.yaml
@@ -100,6 +100,10 @@ spec:
         {{- if .Values.extraVolumes }}
           {{- toYaml .Values.extraVolumes | nindent 6 }}
         {{- end }}
+      {{- else }}
+      volumes:
+        - name: data
+          emptyDir: {}
       {{- end }}
       {{- with .Values.dnsConfig }}
       dnsConfig:

--- a/charts/woodpecker/charts/agent/templates/statefulset.yaml
+++ b/charts/woodpecker/charts/agent/templates/statefulset.yaml
@@ -88,7 +88,7 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- if or (.Values.persistence.enabled) (.Values.extraVolumeMounts) }}
+      {{- if or (and (.Values.persistence.enabled) (.Values.persistence.existingClaim)) (.Values.extraVolumeMounts) }}
       volumes:
         {{- if .Values.persistence.enabled }}
         {{- if .Values.persistence.existingClaim }}

--- a/charts/woodpecker/charts/agent/unittests/statefulset/pvc.yaml
+++ b/charts/woodpecker/charts/agent/unittests/statefulset/pvc.yaml
@@ -2,7 +2,7 @@ suite: test deployment
 templates:
   - templates/statefulset.yaml
 tests:
-  - it: persistence is enabled
+  - it: persistence enabled
     set:
       persistence:
         enabled: true
@@ -10,19 +10,28 @@ tests:
       - equal:
           path: spec.volumeClaimTemplates[0].spec.accessModes[0]
           value: 'ReadWriteOnce'
-      # this should only exist with existingClaim and is otherwise taken care of automatically
-      - equal:
-          path: spec.template.spec.volumes
-          value: null
-  - it: persistence with existingClaim
+  - it: persistence enabled with existingClaim
     set:
       persistence:
         enabled: true
-        existingClaim: foo
+        existingClaim: 'my-claim'
     asserts:
+      - notExists:
+          path: spec.volumeClaimTemplates[0].spec.accessModes[0]
       - equal:
           path: spec.template.spec.volumes
           value:
-            - persistentVolumeClaim:
-                claimName: foo
-              name: agent-config
+            - name: agent-config
+              persistentVolumeClaim:
+                claimName: my-claim
+  - it: persistence disabled
+    set:
+      persistence:
+        enabled: false
+    asserts:
+      - notExists:
+          path: spec.template.spec.volumes
+      - notExists:
+          path: spec.template.spec.containers[0].volumeMounts
+      - notExists:
+          path: spec.volumeClaimTemplates

--- a/charts/woodpecker/charts/agent/unittests/statefulset/pvc.yaml
+++ b/charts/woodpecker/charts/agent/unittests/statefulset/pvc.yaml
@@ -34,7 +34,10 @@ tests:
           value:
             - name: data
               emptyDir: {}
-      - notExists:
+      - equal:
           path: spec.template.spec.containers[0].volumeMounts
+          value:
+            - mountPath: /data
+              name: data
       - notExists:
           path: spec.volumeClaimTemplates

--- a/charts/woodpecker/charts/agent/unittests/statefulset/pvc.yaml
+++ b/charts/woodpecker/charts/agent/unittests/statefulset/pvc.yaml
@@ -29,12 +29,9 @@ tests:
       persistence:
         enabled: false
     asserts:
-      - equal:
+      - notExists:
           path: spec.template.spec.volumes
-          value:
-            - name: data
-              emptyDir: {}
-      - equal:
+      - notExists:
           path: spec.template.spec.containers[0].volumeMounts
           value:
             - mountPath: /data

--- a/charts/woodpecker/charts/agent/unittests/statefulset/pvc.yaml
+++ b/charts/woodpecker/charts/agent/unittests/statefulset/pvc.yaml
@@ -29,8 +29,11 @@ tests:
       persistence:
         enabled: false
     asserts:
-      - notExists:
+      - equal:
           path: spec.template.spec.volumes
+          value:
+            - name: data
+              emptyDir: {}
       - notExists:
           path: spec.template.spec.containers[0].volumeMounts
       - notExists:


### PR DESCRIPTION
Ref #171 

@IceBear2k

I was unable to replicate your issue.

`helm template charts/woodpecker/charts/agent/ --set persistence.enabled=true` renders a valie statefulset for me and doesn't include `volumeMounts` and `volumeClaimTemplates` as shown in your screenshot. Can you verify this on your own? 
Are you setting additional options?

```yml
# Source: agent/templates/statefulset.yaml
apiVersion: apps/v1
kind: StatefulSet
metadata:
  name: release-name-agent
  labels:
    helm.sh/chart: agent-0.3.0
    app.kubernetes.io/name: agent
    app.kubernetes.io/instance: release-name
    app.kubernetes.io/version: "2.4.1"
    app.kubernetes.io/managed-by: Helm
spec:
  serviceName: release-name-agent
  replicas: 2
  selector:
    matchLabels:
      app.kubernetes.io/name: agent
      app.kubernetes.io/instance: release-name
  template:
    metadata:
      labels:
        app.kubernetes.io/name: agent
        app.kubernetes.io/instance: release-name
    spec:
      serviceAccountName: release-name-agent
      securityContext:
        {}
      initContainers:
      containers:
        - name: agent
          securityContext:
            {}
          image: "docker.io/woodpeckerci/woodpecker-agent:v2.4.1"
          imagePullPolicy: IfNotPresent
          ports:
            - name: http
              containerPort: 3000
              protocol: TCP
          resources:
            {}
          volumeMounts:
            - name: agent-config
              mountPath: /etc/woodpecker
          env:
            - name: WOODPECKER_BACKEND
              value: "kubernetes"
            - name: WOODPECKER_BACKEND_K8S_NAMESPACE
              value: "woodpecker"
            - name: WOODPECKER_BACKEND_K8S_POD_ANNOTATIONS
              value: ""
            - name: WOODPECKER_BACKEND_K8S_POD_LABELS
              value: ""
            - name: WOODPECKER_BACKEND_K8S_STORAGE_CLASS
              value: ""
            - name: WOODPECKER_BACKEND_K8S_STORAGE_RWX
              value: "true"
            - name: WOODPECKER_BACKEND_K8S_VOLUME_SIZE
              value: "10G"
            - name: WOODPECKER_CONNECT_RETRY_COUNT
              value: "1"
            - name: WOODPECKER_SERVER
              value: "woodpecker-server:9000"
          envFrom:
            - secretRef:
                name: woodpecker-secret
  volumeClaimTemplates:
    - metadata:
        name: agent-config
        namespace:
        annotations:
      spec:
        accessModes:
          - "ReadWriteOnce"
        resources:
          requests:
            storage: 1Gi
```

In any case, I've also added additional tests in this PR which should verify the behavior described above. The change in `statefuleset.yaml` is only to prevent rendering an empty `volumes:` block, but this is unrelated to the claims in #171. The last test in this PR verifies that the mentioned components should not exist in the STS when setting `persistence.enabled=false`.

From what I can see you are setting `woodpecker.agent.persistence.enabled` which won't have an effect as it should be `agent.persistence.enabled`. Maybe that's the issue?