### PR TITLE
Add option to run pipelines in a different namespace from the agent

### DIFF
--- a/charts/woodpecker/charts/agent/README.md
+++ b/charts/woodpecker/charts/agent/README.md
@@ -21,7 +21,6 @@ A Helm chart for the Woodpecker agent
 | command | list | `[]` | Defines a custom command to start the container |
 | dnsConfig | object | `{}` | Overrides the default DNS configuration |
 | env.WOODPECKER_BACKEND | string | `"kubernetes"` |  |
-| env.WOODPECKER_BACKEND_K8S_NAMESPACE | string | `"woodpecker"` |  |
 | env.WOODPECKER_BACKEND_K8S_POD_ANNOTATIONS | string | `""` |  |
 | env.WOODPECKER_BACKEND_K8S_POD_LABELS | string | `""` |  |
 | env.WOODPECKER_BACKEND_K8S_STORAGE_CLASS | string | `""` |  |
@@ -47,6 +46,7 @@ A Helm chart for the Woodpecker agent
 | persistence.mountPath | string | `"/etc/woodpecker"` | Defines the path where the volume should be mounted |
 | persistence.size | string | `"1Gi"` | Defines the size of the persistent volume |
 | persistence.storageClass | string | `""` | Defines the storageClass of the persistent volume |
+| pipelineNamespace | string | `""` | Specifies the namespace pipelines will be executed in. Default to the same namespace the agent is deployed in. |
 | podAnnotations | object | `{}` | Add pod annotations for the agent component |
 | podSecurityContext | object | `{}` | Add pod security context |
 | replicaCount | int | `2` | The number of replicas for the deployment |

--- a/charts/woodpecker/charts/agent/templates/role.yaml
+++ b/charts/woodpecker/charts/agent/templates/role.yaml
@@ -3,6 +3,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: {{ include "woodpecker-agent.serviceAccountName" . }}
+  {{- if ne .Values.pipelineNamespace "" }}
+  namespace: {{ quote .Values.pipelineNamespace }}
+  {{- end }}
   labels:
     {{- include "woodpecker-agent.labels" . | nindent 4 }}
     {{- with .Values.serviceAccount.rbac.role.labels }}

--- a/charts/woodpecker/charts/agent/templates/rolebinding.yaml
+++ b/charts/woodpecker/charts/agent/templates/rolebinding.yaml
@@ -3,6 +3,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: {{ include "woodpecker-agent.serviceAccountName" . }}
+  {{- if ne .Values.pipelineNamespace "" }}
+  namespace: {{ quote .Values.pipelineNamespace }}
+  {{- end }}
   labels:
     {{- include "woodpecker-agent.labels" . | nindent 4 }}
     {{- with .Values.serviceAccount.rbac.roleBinding.labels }}

--- a/charts/woodpecker/charts/agent/templates/statefulset.yaml
+++ b/charts/woodpecker/charts/agent/templates/statefulset.yaml
@@ -71,6 +71,8 @@ spec:
             - name: {{ $key }}
               value: {{ $value | quote }}
             {{- end }}
+            - name: "WOODPECKER_BACKEND_K8S_NAMESPACE"
+              value: {{ if eq .Values.pipelineNamespace "" }}{{ quote .Release.Namespace }}{{ else }}{{ quote .Values.pipelineNamespace }}{{ end }}
           envFrom:
             {{- range .Values.extraSecretNamesForEnvFrom }}
             - secretRef:

--- a/charts/woodpecker/charts/agent/values.yaml
+++ b/charts/woodpecker/charts/agent/values.yaml
@@ -21,7 +21,6 @@ env:
   # -- Add the environment variables for the agent component
   WOODPECKER_SERVER: 'woodpecker-server:9000'
   WOODPECKER_BACKEND: kubernetes
-  WOODPECKER_BACKEND_K8S_NAMESPACE: woodpecker
   WOODPECKER_BACKEND_K8S_STORAGE_CLASS: ''
   WOODPECKER_BACKEND_K8S_VOLUME_SIZE: 10G
   WOODPECKER_BACKEND_K8S_STORAGE_RWX: true
@@ -156,3 +155,6 @@ topologySpreadConstraints: []
 #   labelSelector:
 #     matchLabels:
 #       "app.kubernetes.io/name": woodpecker-agent
+
+# -- Specifies the namespace pipelines will be executed in. Default to the same namespace the agent is deployed in.
+pipelineNamespace: ""

--- a/charts/woodpecker/values.yaml
+++ b/charts/woodpecker/values.yaml
@@ -28,7 +28,6 @@ agent:
     # -- Add the environment variables for the agent component
     WOODPECKER_SERVER: 'woodpecker-server:9000'
     WOODPECKER_BACKEND: kubernetes
-    WOODPECKER_BACKEND_K8S_NAMESPACE: woodpecker
     WOODPECKER_BACKEND_K8S_STORAGE_CLASS: ''
     WOODPECKER_BACKEND_K8S_VOLUME_SIZE: 10G
     WOODPECKER_BACKEND_K8S_STORAGE_RWX: true


### PR DESCRIPTION
This change adds the option to deploy the agent in one namespace and execute pipelines in a different namespace.