### PR TITLE
Fix release config

### DIFF
--- a/release-config.ts
+++ b/release-config.ts
@@ -1,7 +1,7 @@
 export default {
   commentOnReleasedPullRequests: false,
   beforePrepare: async ({ exec, nextVersion }) => {
-    await exec(`apt-get install -y git curl`);
+    await exec(`apt update && apt-get install -y git curl`);
     await exec(`curl https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash`);
     await exec(`sed -i "s/^version:.*$/version: ${nextVersion}/g" charts/woodpecker/Chart.yaml`);
     await exec('helm dependency update');


### PR DESCRIPTION
https://ci.woodpecker-ci.org/repos/8958/pipeline/933/4

```
# Next version will be: 1.5.2
# Push to release branch detected.
# Preparing release pull-request for version: 1.5.2 ...
Branch "next-release/main" does not exist yet, creating it.
# Running beforePrepare hook
Reading package lists...
Building dependency tree...
Reading state information...
E: Unable to locate package curl
/bin/sh: 1: curl: not found
/bin/sh: 1: helm: not found
# Updating CHANGELOG.md
# Creating release pull-request
# Successfully prepared release pull-request:  { pullRequestLink: 'https://github.com/woodpecker-ci/helm/pull/220' }
# Pull-request created
```