### PR TITLE
Update subcharts and release config

### DIFF
--- a/Chart.lock
+++ b/Chart.lock
@@ -1,9 +1,0 @@
-dependencies:
-- name: server
-  repository: ""
-  version: 1.0.0
-- name: agent
-  repository: ""
-  version: 0.2.0
-digest: sha256:289a2b8d226478642d244f6581215feb7bb142c608d5ceedb3a2aa8b58166688
-generated: "2023-10-16T17:29:54.577011353+02:00"

--- a/charts/woodpecker/Chart.lock
+++ b/charts/woodpecker/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: server
   repository: ""
-  version: 1.0.0
+  version: 1.0.1
 - name: agent
   repository: ""
-  version: 0.3.0
-digest: sha256:5f6be6fdc9fc5d2012bfa9f843f73faae901c8541fc07c713dff5ad2cc2dc75e
-generated: "2024-02-15T20:14:00.795465+01:00"
+  version: 0.3.1
+digest: sha256:814062a80d8b2fea1fede9b7cce3fd75204377fd96147e3e573e3fc0ce2136a4
+generated: "2024-09-12T15:19:06.065499+02:00"

--- a/charts/woodpecker/Chart.yaml
+++ b/charts/woodpecker/Chart.yaml
@@ -27,8 +27,8 @@ sources:
 
 dependencies:
   - name: server
-    version: 1.0.0
+    version: 1.0.1
     condition: server.enabled
   - name: agent
-    version: 0.3.0
+    version: 0.3.1
     condition: agent.enabled

--- a/charts/woodpecker/charts/agent/Chart.yaml
+++ b/charts/woodpecker/charts/agent/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: agent
 description: A Helm chart for the Woodpecker agent
 type: application
-version: 0.3.0
+version: 0.3.1
 # renovate: datasource=github-releases depName=woodpecker-ci/woodpecker extractVersion=^v(?<version>.*)$
 appVersion: 2.7.1
 home: https://woodpecker-ci.org/

--- a/charts/woodpecker/charts/server/Chart.yaml
+++ b/charts/woodpecker/charts/server/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: server
 description: A Helm chart for the Woodpecker server
 type: application
-version: 1.0.0
+version: 1.0.1
 # renovate: datasource=github-releases depName=woodpecker-ci/woodpecker extractVersion=^v(?<version>.*)$
 appVersion: 2.7.1
 home: https://woodpecker-ci.org/

--- a/release-config.ts
+++ b/release-config.ts
@@ -1,10 +1,10 @@
 export default {
   commentOnReleasedPullRequests: false,
   beforePrepare: async ({ exec, nextVersion }) => {
-    await exec(`apt update && apt-get install -y git curl`);
+    await exec(`apt update && apt-get install -y -q git curl`);
     await exec(`curl https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash`);
     await exec(`sed -i "s/^version:.*$/version: ${nextVersion}/g" charts/woodpecker/Chart.yaml`);
-    await exec('helm dependency update');
+    await exec('helm dependency update charts/woodpecker/');
     await exec(
       'git add charts/woodpecker/Chart.yaml charts/woodpecker/charts/agent/Chart.yaml charts/woodpecker/charts/server/Chart.yaml',
     );


### PR DESCRIPTION
Addresses

```
Error: Chart.yaml file is missing
```

when calling `helm dependency update`.

The latter is actually of importance when updating the subchart versions to create a valid `Chart.lock`.
However, we lately didn't update the subchart versions and just bumped the umbrella chart.
There are also no public releases of the subcharts.
While for the server this is debatable, the `agent` chart is actually interesting as this one could be deployed standalone in a meaningful way.

Maybe we should maintain all of them at the same hierarchy level and rename the `woodpecker` chart to `woodpecker-stack`?

