### PR TITLE
Remove uneeded agent role rules

### DIFF
--- a/charts/woodpecker/charts/agent/Chart.yaml
+++ b/charts/woodpecker/charts/agent/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: agent
 description: A Helm chart for the Woodpecker agent
 type: application
-version: 0.3.0
+version: 0.4.0
 # renovate: datasource=github-releases depName=woodpecker-ci/woodpecker extractVersion=^v(?<version>.*)$
 appVersion: 2.7.1
 home: https://woodpecker-ci.org/

--- a/charts/woodpecker/charts/agent/templates/role.yaml
+++ b/charts/woodpecker/charts/agent/templates/role.yaml
@@ -19,6 +19,9 @@ rules:
   - apiGroups: ['']
     resources:
       - pods
-      - pods/log
     verbs: ['watch','create','delete','get','list']
+  - apiGroups: ['']
+    resources:
+      - pods/log
+    verbs: ['get']
 {{- end }}


### PR DESCRIPTION
Present, the chart adds the meaningless RBAC rules for verbs `create`, `update`, `list`, and `delete` for the `pods/log` resource. While this is allowed, these permissions are meaningless, and are never checked for by Kubernetes.

While this is not an issue in of itself, within Kubernetes, a user must be granted a permission in order to create a Role or RoleBinding that grants it. In centrally-managed multi-tenant clusters, it is unlikely that these meaningless permissions will be granted by default unless the user is a cluster or namespace administrator (i.e. `*` verb granted), or specifically requested, meaning the chart is unusable by those unprivileged users in its current state.

This patch splits out just the single necessary `get` verb for `pods/log` so that unprivileged users can deploy the chart.