### PR TITLE
Publish chart to ghcr

### DIFF
--- a/.woodpecker/release.yml
+++ b/.woodpecker/release.yml
@@ -9,8 +9,7 @@ steps:
   pack-chart:
     image: quay.io/helmpack/chart-releaser:v1.6.1
     commands:
-      - mkdir -p .cr-index
-      - cr package charts/woodpecker
+      - helm package --version "${GITHUB_REF_NAME#v}" -d tmp/ charts/woodpecker
 
   release-chart:
     image: quay.io/helmpack/chart-releaser:v1.6.1
@@ -27,6 +26,17 @@ steps:
       - cd ..
       - rm -rf woodpecker-ci.github.io/
       - git reset --hard
+    when:
+      - event: tag
+
+  release-chart-ghcr:
+    image: alpine/helm:3.16.1
+    secrets:
+      - github_token
+    commands:
+      - helm package --version "${CI_COMMIT_TAG}" -d tmp/ charts/woodpecker
+      - echo $GITHUB_TOKEN | helm registry login ghcr.io --username woodpecker-ci --password-stdin
+      - helm push tmp/woodpecker-${CI_COMMIT_TAG}.tgz oci://ghcr.io/woodpecker-ci/helm
     when:
       - event: tag
 

--- a/.woodpecker/release.yml
+++ b/.woodpecker/release.yml
@@ -9,7 +9,8 @@ steps:
   pack-chart:
     image: quay.io/helmpack/chart-releaser:v1.6.1
     commands:
-      - helm package --version "${GITHUB_REF_NAME#v}" -d tmp/ charts/woodpecker
+      - mkdir -p .cr-index
+      - cr package charts/woodpecker
 
   release-chart:
     image: quay.io/helmpack/chart-releaser:v1.6.1

--- a/charts/woodpecker/README.md
+++ b/charts/woodpecker/README.md
@@ -1,6 +1,6 @@
 # woodpecker
 
-![Version: 1.5.1](https://img.shields.io/badge/Version-1.5.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.7.0](https://img.shields.io/badge/AppVersion-2.7.0-informational?style=flat-square)
+![Version: 1.5.2](https://img.shields.io/badge/Version-1.5.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.7.1](https://img.shields.io/badge/AppVersion-2.7.1-informational?style=flat-square)
 
 **Source Code**: <https://github.com/woodpecker-ci/woodpecker>
 
@@ -9,6 +9,11 @@
 To install the latest release of the chart:
 
 ```sh
+# since > 1.6.1
+helm repo add woodpecker oci://ghcr.io/woodpecker-ci/helm
+helm install woodpecker woodpecker/woodpecker
+
+# deprecated (but still functional)
 helm repo add woodpecker https://woodpecker-ci.org/
 helm install woodpecker woodpecker/woodpecker
 ```
@@ -30,7 +35,7 @@ resource "helm_release" "woodpecker" {
   chart            = "woodpecker"
   repository       = "https://woodpecker-ci.org/"
   create_namespace = true # optional
-  version          = 1.5.1
+  version          = 1.5.2
   namespace        = "woodpecker"
   count            = 1 # optional
   timeout          = 90 # optional
@@ -51,8 +56,8 @@ resource "helm_release" "woodpecker" {
 
 | Repository | Name | Version |
 |------------|------|---------|
-|  | agent | 0.3.0 |
-|  | server | 1.0.0 |
+|  | agent | 0.4.0 |
+|  | server | 1.0.1 |
 
 ## Values
 

--- a/charts/woodpecker/README.md.gotmpl
+++ b/charts/woodpecker/README.md.gotmpl
@@ -11,6 +11,11 @@
 To install the latest release of the chart:
 
 ```sh
+# since > 1.6.1
+helm repo add woodpecker oci://ghcr.io/woodpecker-ci/helm
+helm install woodpecker woodpecker/woodpecker
+
+# deprecated (but still functional)
 helm repo add woodpecker https://woodpecker-ci.org/
 helm install woodpecker woodpecker/woodpecker
 ```


### PR DESCRIPTION
The idea would be to publish to both sources for a few releases and promote the older approach as deprecated.

Advantages for ghcr:

- Better visibility and "closeness" to the repo than using gh-pages
- Simpler and cleaner release code
- OCI registries are the "new" standard for helm charts

Todo:
- [x] `gh_token` secret must have `packages` scope
- [ ] should be tested locally by someone with access to `gh_token`