### PR TITLE
release-plugin: don't include contributors

### DIFF
--- a/release-config.ts
+++ b/release-config.ts
@@ -1,5 +1,6 @@
 export default {
   commentOnReleasedPullRequests: false,
+  includeContributors: false,
   beforePrepare: async ({ exec, nextVersion }) => {
     await exec(`apt update && apt-get install -y -q git curl`);
     await exec(`curl https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash`);


### PR DESCRIPTION
They are listed anyhow by default:

<img width="559" alt="image" src="https://github.com/user-attachments/assets/fbcb1386-cccd-4a74-beb9-19f2d98569b2">

In addition, the (hardcoded) default including the two hearts looks somewhat unprofessional (personal opinion).

I am not 100% sure if the config option is honored though, I found it here: https://github.com/woodpecker-ci/plugin-ready-release-go/blob/7aea0c10ee3e72ea9730ec99d6af1132c46f14b4/src/utils/change.ts#L98C7-L98C26. 
@anbraten might know better.