### PR TITLE
Refine CODEOWNER

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-* @pat-s @anbraten @xoxys
+charts/ @pat-s @anbraten @xoxys


### PR DESCRIPTION
Background:

- `renovate-approve` bot doesn't work when CODEOWNER reviews are required
- `renovate-approve` bot can't be added as a CODEOWNER
- review requests for renovate dep updates in `.woodpecker` creates unneeded noise

Yes, renovate tracks some files in `charts/` but these are effectively managed by the release plugin before renovate takes action.