### PR TITLE
fix: update tarball output dir

### DIFF
--- a/.woodpecker/release.yml
+++ b/.woodpecker/release.yml
@@ -36,9 +36,9 @@ steps:
       GITHUB_TOKEN:
         from_secret: github_token
     commands:
-      - helm package --version "${CI_COMMIT_TAG}" -d tmp/ charts/woodpecker
+      - helm package --version "${CI_COMMIT_TAG}" -d /tmp/ charts/woodpecker
       - echo $GITHUB_TOKEN | helm registry login ghcr.io --username ignored --password-stdin
-      - helm push tmp/woodpecker-${CI_COMMIT_TAG}.tgz oci://ghcr.io/woodpecker-ci/helm
+      - helm push /tmp/woodpecker-${CI_COMMIT_TAG}.tgz oci://ghcr.io/woodpecker-ci/helm
     when:
       - event: tag
 


### PR DESCRIPTION
The latest release accidentally pushed the tarball into the repo: https://github.com/woodpecker-ci/helm/tree/main/tmp