### PR TITLE
use `curl` instead of `cr`

### DIFF
--- a/.woodpecker/release.yml
+++ b/.woodpecker/release.yml
@@ -7,26 +7,21 @@ when:
 
 steps:
   pack-chart:
-    image: quay.io/helmpack/chart-releaser:v1.7.0
+    image: alpine/helm:3.16.4
     commands:
-      - mkdir -p .cr-index
-      - cr package charts/woodpecker
+      - helm package --version "${CI_COMMIT_TAG#v}" -d /tmp/ charts/woodpecker
 
   release-chart:
-    image: quay.io/helmpack/chart-releaser:v1.7.0
+    image: alpine:3.21
     environment:
-      CR_TOKEN:
+      GITHUB_TOKEN:
         from_secret: github_token
-    commands:
-      - git config --global user.email "woodpecker-bot@obermui.de"
-      - git config --global user.name "woodpecker-bot"
-      - cr upload --skip-existing --owner woodpecker-ci --git-repo woodpecker-ci.github.io --release-name-template "helm-{{ .Name }}-{{ .Version }}"
-      - git clone https://github.com/woodpecker-ci/woodpecker-ci.github.io.git
-      - cd woodpecker-ci.github.io/
-      - cr index --owner woodpecker-ci --git-repo woodpecker-ci.github.io --pages-branch main --package-path ../.cr-release-packages --index-path ../.cr-index/index.yaml --push --release-name-template "helm-{{ .Name }}-{{ .Version }}"
-      - cd ..
-      - rm -rf woodpecker-ci.github.io/
-      - git reset --hard
+    commands: |
+      apk add -q --no-cache curl jq
+
+      UPLOAD_URL=$(curl -s --user woodpecker-bot:$GITHUB_TOKEN -X POST -H "Accept: application/vnd.github.v3+json" https://api.github.com/repos/$CI_REPO_OWNER/$CI_REPO_NAME/releases -d "{\"tag_name\":\"${CI_COMMIT_TAG#v}\",\"name\":\"helm-woodpecker-${CI_COMMIT_TAG#v}\",\"body\":\"A Helm chart for Woodpecker CI\"}" | jq -r .upload_url | sed -e "s/{?name,label}//")
+
+      curl -v --user woodpecker-bot:$GITHUB_TOKEN -X POST --header "Content-Type: application/gzip" --data-binary @/tmp/woodpecker-${CI_COMMIT_TAG#v}.tgz "$UPLOAD_URL?name=woodpecker-${CI_COMMIT_TAG#v}.tgz"
     when:
       - event: tag
 
@@ -36,7 +31,6 @@ steps:
       GITHUB_TOKEN:
         from_secret: github_token
     commands:
-      - helm package --version "${CI_COMMIT_TAG}" -d /tmp/ charts/woodpecker
       - echo $GITHUB_TOKEN | helm registry login ghcr.io --username ignored --password-stdin
       - helm push /tmp/woodpecker-${CI_COMMIT_TAG}.tgz oci://ghcr.io/woodpecker-ci/helm
     when:


### PR DESCRIPTION
More issues than help. Broke again after the most recent `1.7` release when releasing chart 2.0.4.

A `curl` command to upload to create a GH release directly should be more resilient.