### PR TITLE
Revert "chore(deps): update quay.io/helmpack/chart-releaser docker tag to v1.7.0 (#305)"

### DIFF
--- a/.woodpecker/release.yml
+++ b/.woodpecker/release.yml
@@ -7,20 +7,20 @@ when:
 
 steps:
   pack-chart:
-    image: quay.io/helmpack/chart-releaser:v1.7.0
+    image: quay.io/helmpack/chart-releaser:v1.6.1
     commands:
       - mkdir -p .cr-index
       - cr package charts/woodpecker
 
   release-chart:
-    image: quay.io/helmpack/chart-releaser:v1.7.0
+    image: quay.io/helmpack/chart-releaser:v1.6.1
     environment:
       CR_TOKEN:
         from_secret: github_token
     commands:
       - git config --global user.email "woodpecker-bot@obermui.de"
       - git config --global user.name "woodpecker-bot"
-      - cr upload --skip-existing --owner woodpecker-ci --git-repo woodpecker-ci.github.io --pages-branch main --release-name-template "helm-{{ .Name }}-{{ .Version }}"
+      - cr upload --skip-existing --owner woodpecker-ci --git-repo woodpecker-ci.github.io --release-name-template "helm-{{ .Name }}-{{ .Version }}"
       - git clone https://github.com/woodpecker-ci/woodpecker-ci.github.io.git
       - cd woodpecker-ci.github.io/
       - cr index --owner woodpecker-ci --git-repo woodpecker-ci.github.io --pages-branch main --package-path ../.cr-release-packages --index-path ../.cr-index/index.yaml --push --release-name-template "helm-{{ .Name }}-{{ .Version }}"


### PR DESCRIPTION
This reverts commit 39034445106186ed4dd555748c9a8c06f85eb35e.

Ref: https://github.com/woodpecker-ci/helm/issues/323