### PR TITLE
Add configurable prober options for woodpecker server

### DIFF
--- a/charts/woodpecker/charts/server/templates/statefulset.yaml
+++ b/charts/woodpecker/charts/server/templates/statefulset.yaml
@@ -70,10 +70,26 @@ spec:
             httpGet:
               path: /healthz
               port: 8000
+            {{- if .Values.probes }}
+            {{- with .Values.probes.liveness }}
+            timeoutSeconds: {{ .timeoutSeconds | default 10 }}
+            periodSeconds: {{ .periodSeconds | default 10 }}
+            successThreshold: {{ .successThreshold | default 1 }}
+            failureThreshold: {{ .failureThreshold | default 3 }}
+            {{- end }}
+            {{- end }}
           readinessProbe:
             httpGet:
               path: /healthz
               port: 8000
+            {{- if .Values.probes }}
+            {{- with .Values.probes.readiness }}
+            timeoutSeconds: {{ .timeoutSeconds | default 10 }}
+            periodSeconds: {{ .periodSeconds | default 10 }}
+            successThreshold: {{ .successThreshold | default 1 }}
+            failureThreshold: {{ .failureThreshold | default 3 }}
+            {{- end }}
+            {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           volumeMounts:

--- a/charts/woodpecker/charts/server/values.yaml
+++ b/charts/woodpecker/charts/server/values.yaml
@@ -227,6 +227,29 @@ resources:
   #   cpu: 100m
   #   memory: 128Mi
 
+# -- Configure probe options for container health checking
+probes:
+  # -- Configure liveness probe options
+  liveness:
+    # -- Number of seconds after which the probe times out (default: 10)
+    timeoutSeconds: 10
+    # -- How often (in seconds) to perform the probe (default: 10)
+    periodSeconds: 10
+    # -- Minimum consecutive successes for the probe to be considered successful after having failed (default: 1)
+    successThreshold: 1
+    # -- When a probe fails, Kubernetes will try failureThreshold times before giving up (default: 3)
+    failureThreshold: 3
+  # -- Configure readiness probe options
+  readiness:
+    # -- Number of seconds after which the probe times out (default: 10)
+    timeoutSeconds: 10
+    # -- How often (in seconds) to perform the probe (default: 10)
+    periodSeconds: 10
+    # -- Minimum consecutive successes for the probe to be considered successful after having failed (default: 1)
+    successThreshold: 1
+    # -- When a probe fails, Kubernetes will try failureThreshold times before giving up (default: 3)
+    failureThreshold: 3
+
 # -- Defines the labels of the node where the server component must be running
 nodeSelector: {}
 

--- a/charts/woodpecker/values.yaml
+++ b/charts/woodpecker/values.yaml
@@ -325,3 +325,26 @@ server:
 
   # -- Overrides the default DNS configuration
   dnsConfig: {}
+
+  # -- Configure probe options for container health checking
+  probes:
+    # -- Configure liveness probe options
+    liveness:
+      # -- Number of seconds after which the probe times out (default: 10)
+      timeoutSeconds: 10
+      # -- How often (in seconds) to perform the probe (default: 10)
+      periodSeconds: 10
+      # -- Minimum consecutive successes for the probe to be considered successful after having failed (default: 1)
+      successThreshold: 1
+      # -- When a probe fails, Kubernetes will try failureThreshold times before giving up (default: 3)
+      failureThreshold: 3
+    # -- Configure readiness probe options
+    readiness:
+      # -- Number of seconds after which the probe times out (default: 10)
+      timeoutSeconds: 10
+      # -- How often (in seconds) to perform the probe (default: 10)
+      periodSeconds: 10
+      # -- Minimum consecutive successes for the probe to be considered successful after having failed (default: 1)
+      successThreshold: 1
+      # -- When a probe fails, Kubernetes will try failureThreshold times before giving up (default: 3)
+      failureThreshold: 3


### PR DESCRIPTION
Woodpecker Server StatefulSet generates `livenessProbe` and `readinessProbe` with default values.

Relevant section of the generated yaml looks like:
```
      livenessProbe:
        httpGet:
          path: /healthz
          port: 8000
          scheme: HTTP
        timeoutSeconds: 1
        periodSeconds: 10
        successThreshold: 1
        failureThreshold: 3
      readinessProbe:
        httpGet:
          path: /healthz
          port: 8000
          scheme: HTTP
        timeoutSeconds: 1
        periodSeconds: 10
        successThreshold: 1
        failureThreshold: 3
```

Under load, I've noticed that liveness probes timed out in quick succession, which leads to the server getting restarted.

This PR adds configuration options to the template and surfaces them through server/values.yaml and values.yaml