### PR TITLE
Add api version and kind to volume claim template

### DIFF
--- a/charts/woodpecker/charts/agent/templates/statefulset.yaml
+++ b/charts/woodpecker/charts/agent/templates/statefulset.yaml
@@ -112,7 +112,9 @@ spec:
 
 {{- if and (not .Values.persistence.existingClaim) .Values.persistence.enabled }}
   volumeClaimTemplates:
-    - metadata:
+    - apiVersion: v1
+      kind: PersistentVolumeClaim
+      metadata:
         name: agent-config
         namespace: {{ $.namespace }}
         annotations:

--- a/charts/woodpecker/charts/server/templates/statefulset.yaml
+++ b/charts/woodpecker/charts/server/templates/statefulset.yaml
@@ -140,7 +140,9 @@ spec:
       {{- end }}
   {{- if .Values.persistentVolume.enabled }}
   volumeClaimTemplates:
-  - metadata:
+  - apiVersion: v1
+    kind: PersistentVolumeClaim
+    metadata:
       name: data
     spec:
       accessModes: [ "ReadWriteOnce" ]


### PR DESCRIPTION
due to missing apiVersion and kind headers argocd always detects a diff.

This commit adds the optional fields that resolve this issue.

![grafik](https://github.com/user-attachments/assets/9167ac5d-3cb6-48e4-92de-19c9de1bf9fb)
