### PR TITLE
Agent on different machine, GRPCRoute issue, Gateway SSL terminated

### DIFF
--- a/charts/woodpecker/charts/server/templates/service.yaml
+++ b/charts/woodpecker/charts/server/templates/service.yaml
@@ -25,6 +25,9 @@ spec:
       name: grpc
       port: 9000
       targetPort: grpc
+      {{- with .Values.service.appProtocol }}
+      appProtocol: {{ . }}
+      {{- end }}
     {{- if .Values.metrics.enabled }}
     - protocol: TCP
       name: metrics

--- a/charts/woodpecker/charts/server/templates/service.yaml
+++ b/charts/woodpecker/charts/server/templates/service.yaml
@@ -25,9 +25,7 @@ spec:
       name: grpc
       port: 9000
       targetPort: grpc
-      {{- with .Values.service.appProtocol }}
-      appProtocol: {{ . }}
-      {{- end }}
+      appProtocol: kubernetes.io/h2c
     {{- if .Values.metrics.enabled }}
     - protocol: TCP
       name: metrics

--- a/charts/woodpecker/charts/server/values.yaml
+++ b/charts/woodpecker/charts/server/values.yaml
@@ -149,6 +149,8 @@ service:
   loadBalancerIP:
   # -- Annotations to add to the service
   annotations: {}
+  # -- https://kubernetes.io/docs/concepts/services-networking/service/#application-protocol
+  appProtocol: ""
 
 ingress:
   # -- Enable the ingress for the server component

--- a/charts/woodpecker/charts/server/values.yaml
+++ b/charts/woodpecker/charts/server/values.yaml
@@ -149,8 +149,6 @@ service:
   loadBalancerIP:
   # -- Annotations to add to the service
   annotations: {}
-  # -- https://kubernetes.io/docs/concepts/services-networking/service/#application-protocol
-  appProtocol: ""
 
 ingress:
   # -- Enable the ingress for the server component


### PR DESCRIPTION
```log
Apr 29 13:42:28 machine woodpecker-agent[676302]: {"level":"fatal","error":"agent could not auth: rpc error: code = Unavailable 
desc = upstream connect error or disconnect/reset before headers. reset reason: protocol error","time":"2026-04-29T13:42:28+08:0
0","message":"error running agent"}
```
I'm separating server(k3s) and agent(backend to local on another machine)

to fix/workaround:

`appProtocol: kubernetes.io/h2c` is needed on [`service:`](https://kubernetes.io/docs/concepts/services-networking/service/#application-protocol) to link external agent to server(k3s+gtw+ssl-term) to fix above fatal error.
