### PR TITLE
Removed duplicated <details> block fron agent helm docs

### DIFF
--- a/charts/woodpecker/charts/agent/README.md
+++ b/charts/woodpecker/charts/agent/README.md
@@ -24,15 +24,11 @@ See the [3.0.0 release notes](https://woodpecker-ci.org/migrations#300).
 
 <details>
 
-<details>
-
 <summary>To 1.0.0</summary>
 
 - If you have injected/defined the env var `WOODPECKER_AGENT_SECRET` manually, you need to decide whether you want to continue doing so (if yes, set `mapAgentSecret: false`) or if you want to make use of the new `mapAgentSecret: true` option (new default). This option maps an existing k8s secret in the same namespace into the statefulset.
 
 </details>
-
-<details>
 
 ## Values
 


### PR DESCRIPTION
Removed redundant details sections preventing the values section from showing up unless opening the details block twice.