### PR TITLE
Fix YAML parse error when persistence.existingClaim and extraVolumeMounts

### DIFF
--- a/charts/woodpecker/charts/agent/templates/statefulset.yaml
+++ b/charts/woodpecker/charts/agent/templates/statefulset.yaml
@@ -109,7 +109,7 @@ spec:
         {{- end }}
         {{- end }}
         {{- if .Values.extraVolumes }}
-          {{- toYaml .Values.extraVolumes | nindent 6 }}
+          {{- toYaml .Values.extraVolumes | nindent 8 }}
         {{- end }}
       {{- end }}
       {{- with .Values.dnsConfig }}

--- a/charts/woodpecker/charts/agent/unittests/statefulset/volumes.yaml
+++ b/charts/woodpecker/charts/agent/unittests/statefulset/volumes.yaml
@@ -1,0 +1,64 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/helm-unittest/helm-unittest/main/schema/helm-testsuite.json
+suite: extraVolumes and extraVolumeMounts template (basic)
+release:
+  name: woodpecker-unittests
+  namespace: testing
+templates:
+  - templates/statefulset.yaml
+tests:
+  - it: renders extraVolumes and existingClaim together in volumes
+    set:
+      persistence:
+        enabled: true
+        existingClaim: existing-claim
+      extraVolumes:
+        - name: docker-config
+          configMap:
+            name: docker-config
+      extraVolumeMounts:
+        - name: docker-config
+          mountPath: /etc/docker
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: spec.template.spec.volumes
+          value:
+            - name: agent-config
+              persistentVolumeClaim:
+                claimName: existing-claim
+            - configMap:
+                name: docker-config
+              name: docker-config
+
+  - it: renders valid extraVolumes and extraVolumeMounts
+    set:
+      extraVolumes:
+        - name: docker-config
+          configMap:
+            name: docker-config
+        - name: data-volume
+          persistentVolumeClaim:
+            claimName: example
+      extraVolumeMounts:
+        - name: docker-config
+          mountPath: /etc/docker
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: spec.template.spec.containers[0].volumeMounts
+          value:
+            - mountPath: /etc/woodpecker
+              name: agent-config
+            - mountPath: /etc/docker
+              name: docker-config
+      - equal:
+          path: spec.template.spec.volumes
+          value:
+            - configMap:
+                name: docker-config
+              name: docker-config
+            - name: data-volume
+              persistentVolumeClaim:
+                claimName: example


### PR DESCRIPTION
Deploying the agent with `extraVolumes` and `persistence.existingClaim` set result in error:

```
error: Error: YAML parse error on woodpecker/charts/agent/templates/statefulset.yaml: error converting YAML to JSON: yaml: line 75: did not find expected key
```

Changing indentation from 6 to 8 fixes. it.



Here is fragment from my config where I was testing few different things which resulted in above error:

```yaml
agent:
  persistence:
    enabled: true
    existingClaim: woodpecker-pvc
    size: 1Gi
    mountPath: '/etc/woodpecker'
    storageClass: 'local-storage'
    accessModes:
      - ReadWriteOnce

  extraVolumes:
    - name: my-ca
      secret:
        secretName: my-root-ca
        items:
        - key: my-ca.crt
          path: my-ca.crt

  extraVolumeMounts:
    - name: my-ca
      mountPath: /etc/ssl/certs/my-ca.crt
    - name: my-ca
      mountPath: /etc/buildkit/certs/makeit-ca.crt
```