### PR TITLE
Put helm repo first in sources for OCI `image.source`

### DIFF
--- a/charts/woodpecker/Chart.yaml
+++ b/charts/woodpecker/Chart.yaml
@@ -22,8 +22,8 @@ keywords:
   - kubernetes
 
 sources:
+  - https://github.com/woodpecker-ci/helm.git  # First item because it's used by `helm push` for the `org.opencontainers.image.source` OCI annotation
   - https://github.com/woodpecker-ci/woodpecker.git
-  - https://github.com/woodpecker-ci/helm.git
 
 dependencies:
   - name: server


### PR DESCRIPTION
The [first item in `sources` list](https://github.com/helm/helm/blob/2a29f1770b62844b27197d2507377361d45ad7c0/pkg/registry/chart.go#L82
) is used by `helm push` to dynamically set the `org.opencontainers.image.source` OCI annotation:

It can be used by humans and tools alike to find the source of the image.
Renovate (https://renovatebot.com/) for example uses it to fetch the corresponding release notes. Previously it would show the release notes of the main woodpecker repo instead of the release notes for the helm chart.