### PR TITLE
Move `WOODPECKER_DATABASE_DATASOURCE` to server env

### DIFF
--- a/charts/woodpecker/values.yaml
+++ b/charts/woodpecker/values.yaml
@@ -35,11 +35,6 @@ agent:
     WOODPECKER_BACKEND_K8S_POD_LABELS: ''
     WOODPECKER_BACKEND_K8S_POD_ANNOTATIONS: ''
     WOODPECKER_CONNECT_RETRY_COUNT: '1'
-  # WOODPECKER_DATABASE_DATASOURCE:
-  #   valueFrom:
-  #     secretKeyRef:
-  #       name: woodpecker-database-secret
-  #       key: datasource
 
   # -- Add extra secret that is contains environment variables
   extraSecretNamesForEnvFrom: []
@@ -195,6 +190,11 @@ server:
     WOODPECKER_ADMIN: 'woodpecker,admin'
     WOODPECKER_HOST: 'https://xxxxxxx'
     # WOODPECKER_GITHUB: "true"
+    # WOODPECKER_DATABASE_DATASOURCE:
+    #   valueFrom:
+    #     secretKeyRef:
+    #       name: woodpecker-database-secret
+    #       key: datasource
 
   # -- Add extra environment variables from the secrets list
   extraSecretNamesForEnvFrom: []


### PR DESCRIPTION
Exisiting `values.yaml` at the composite chart level, had the environment variable `WOODPECKER_DATABASE_DATASOURCE` under the section `agent`. This is not a valid environment variable for agent.

This commit moved the environment variable to the server section, where it actually needed.